### PR TITLE
Manually add libprotobuf4251 migration

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,7 +17,7 @@ docker_image:
 libabseil:
 - '20230802'
 libprotobuf:
-- 4.24.4
+- 4.25.1
 target_platform:
 - linux-64
 tinyxml2:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -21,7 +21,7 @@ docker_image:
 libabseil:
 - '20230802'
 libprotobuf:
-- 4.24.4
+- 4.25.1
 target_platform:
 - linux-aarch64
 tinyxml2:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -17,7 +17,7 @@ docker_image:
 libabseil:
 - '20230802'
 libprotobuf:
-- 4.24.4
+- 4.25.1
 target_platform:
 - linux-ppc64le
 tinyxml2:

--- a/.ci_support/migrations/libprotobuf4251.yaml
+++ b/.ci_support/migrations/libprotobuf4251.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libprotobuf 4.25.1
+  kind: version
+  migration_number: 1
+libgrpc:
+- "1.60"
+libprotobuf:
+- 4.25.1
+migrator_ts: 1705841975.2201185

--- a/.ci_support/migrations/tinyxml210.yaml
+++ b/.ci_support/migrations/tinyxml210.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for tinyxml2 10
-  kind: version
-  migration_number: 1
-migrator_ts: 1704497957.887235
-tinyxml2:
-- '10'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 libabseil:
 - '20230802'
 libprotobuf:
-- 4.24.4
+- 4.25.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 libabseil:
 - '20230802'
 libprotobuf:
-- 4.24.4
+- 4.25.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 libabseil:
 - '20230802'
 libprotobuf:
-- 4.24.4
+- 4.25.1
 target_platform:
 - win-64
 tinyxml2:

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,22 @@
 # Everything else is managed by the conda-smithy rerender process.
 # Please do not modify
 
+# Ignore all files and folders in root
 *
 !/conda-forge.yml
 
-!/*/
+# Don't ignore any files/folders if the parent folder is 'un-ignored'
+# This also avoids warnings when adding an already-checked file with an ignored parent.
+!/**/
+# Don't ignore any files/folders recursively in the following folders
 !/recipe/**
 !/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
 
 *.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -57,12 +57,6 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
-if [[ "${sha:-}" == "" ]]; then
-  pushd ${FEEDSTOCK_ROOT}
-  sha=$(git rev-parse HEAD)
-  popd
-fi
-
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
       - fixprotobuf23.patch
 
 build:
-  number: 4
+  number: 5
 
 outputs:
   - name: {{ cxx_name }}


### PR DESCRIPTION
Manually handled due to https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/5435 .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
