### PR TITLE
Add runtime dependency of gz-msgs python messages on major protobuf version

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,8 +4,8 @@ bot:
   - v10
   automerge: true
 build_platform:
-  linux_aarch64: linux_aarch64
-  linux_ppc64le: linux_ppc64le
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
   osx_arm64: osx_64
 conda_build:
   pkg_format: '2'

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,6 +12,7 @@ zip_keys:
     - libabseil
     - libgrpc
     - libprotobuf
+    - PROTOBUF_MAJOR_VERSION
 python:
   # part of a zip_keys: python, python_impl, numpy
   - 3.11.* *_cpython
@@ -22,14 +23,17 @@ numpy:
   # part of a zip_keys: python, python_impl, numpy
   - 1.23
 libabseil:
-  # part of a zip_keys: libabseil, libgrpc, libprotobuf
+  # part of a zip_keys: libabseil, libgrpc, libprotobuf, PROTOBUF_MAJOR_VERSION
   - '20240116'
   - '20240722'
 libgrpc:
-  # part of a zip_keys: libabseil, libgrpc, libprotobuf
+  # part of a zip_keys: libabseil, libgrpc, libprotobuf, PROTOBUF_MAJOR_VERSION
   - "1.62"
   - "1.65"
 libprotobuf:
-  # part of a zip_keys: libabseil, libgrpc, libprotobuf
+  # part of a zip_keys: libabseil, libgrpc, libprotobuf, PROTOBUF_MAJOR_VERSION
   - 4.25.3
   - 5.27.5
+PROTOBUF_MAJOR_VERSION:
+  - 4
+  - 5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
       - win_enable_py_tests.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: {{ cxx_name }}
@@ -68,6 +68,7 @@ outputs:
   - name: {{ python_name }}
     build:
       noarch: python
+      string: protobuf{{ PROTOBUF_MAJOR_VERSION }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
     script: build_py.sh  # [unix]
     script: bld_py.bat  # [win]
     requirements:
@@ -97,7 +98,9 @@ outputs:
         - dlfcn-win32  # [win]
       run:
         - python  >=3.8
-        - protobuf
+        # We need to ensure that at runtime we use the same major protobuf
+        # version that was used to generate the python messages
+        - protobuf {{ PROTOBUF_MAJOR_VERSION }}.*
     test:
       commands:
         - pip check
@@ -111,6 +114,10 @@ outputs:
       run_exports:
         - {{ pin_subpackage(cxx_name, max_pin='x') }}
     requirements:
+      host:
+        # Manually ensure that libabseil and libprotobuf end up in the hash
+        - libabseil
+        - libprotobuf
       run:
         - {{ pin_subpackage(cxx_name, exact=True) }}
         - {{ pin_subpackage(python_name, max_pin='x.x.x') }}


### PR DESCRIPTION

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
