### PR TITLE
Remove dual protobuf builds to allow protobuf migrations

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,18 +1,11 @@
 # Hardcode python version to avoid have one build job
 # for python version as in the end the generated
 # artifacts do not depend on Python version
-# Hardcode double protobuf pinning as a workaround for https://github.com/conda-forge/gz-common-feedstock/issues/48
-# remove once https://github.com/conda-forge/openvino-feedstock/pull/106 is merged
 zip_keys:
   -
     - python
     - numpy
     - python_impl
-  -
-    - libabseil
-    - libgrpc
-    - libprotobuf
-    - PROTOBUF_MAJOR_VERSION
 python:
   # part of a zip_keys: python, python_impl, numpy
   - 3.11.* *_cpython
@@ -22,18 +15,3 @@ python_impl:
 numpy:
   # part of a zip_keys: python, python_impl, numpy
   - 1.23
-libabseil:
-  # part of a zip_keys: libabseil, libgrpc, libprotobuf, PROTOBUF_MAJOR_VERSION
-  - '20240116'
-  - '20240722'
-libgrpc:
-  # part of a zip_keys: libabseil, libgrpc, libprotobuf, PROTOBUF_MAJOR_VERSION
-  - "1.62"
-  - "1.65"
-libprotobuf:
-  # part of a zip_keys: libabseil, libgrpc, libprotobuf, PROTOBUF_MAJOR_VERSION
-  - 4.25.3
-  - 5.27.5
-PROTOBUF_MAJOR_VERSION:
-  - 4
-  - 5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,6 +6,7 @@
 {% set component_version = component_name + major_version %}
 {% set cxx_name = "lib" + name %}
 {% set python_name = name + "-python" %}
+{% set protobuf_major_version = "5" %}
 
 
 package:
@@ -19,7 +20,7 @@ source:
       - win_enable_py_tests.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ cxx_name }}
@@ -68,7 +69,7 @@ outputs:
   - name: {{ python_name }}
     build:
       noarch: python
-      string: protobuf{{ PROTOBUF_MAJOR_VERSION }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+      string: protobuf{{ protobuf_major_version }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
     script: build_py.sh  # [unix]
     script: bld_py.bat  # [win]
     requirements:
@@ -93,14 +94,14 @@ outputs:
         - libabseil
         - libprotobuf
         - python
-        - protobuf
+        - protobuf {{ protobuf_major_version }}.*
         - pytest
         - dlfcn-win32  # [win]
       run:
         - python  >=3.8
         # We need to ensure that at runtime we use the same major protobuf
         # version that was used to generate the python messages
-        - protobuf {{ PROTOBUF_MAJOR_VERSION }}.*
+        - protobuf {{ protobuf_major_version }}.*
     test:
       commands:
         - pip check


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
