### PR TITLE
[v11] Fix build string of python package

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -86,7 +86,7 @@ outputs:
       name: ${{ python_name }}
     build:
       noarch: python
-      string: protobuf${{ protobuf_major_version }}h${{ env.get(PKG_HASH) }}_${{ env.get(PKG_BUILDNUM) }}
+      string: protobuf${{ protobuf_major_version }}h${{ hash }}_${{ build_number }}
       script:
         - if: unix
           then: build_py.sh

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -86,7 +86,7 @@ outputs:
       name: ${{ python_name }}
     build:
       noarch: python
-      string: protobuf${{ protobuf_major_version }}h${{ hash }}_${{ build_number }}
+      string: protobuf${{ protobuf_major_version }}h${{ hash }}_${{ number }}
       script:
         - if: unix
           then: build_py.sh

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -86,7 +86,7 @@ outputs:
       name: ${{ python_name }}
     build:
       noarch: python
-      string: protobuf${{ protobuf_major_version }}h${{ PKG_HASH }}_${{ PKG_BUILDNUM }}
+      string: protobuf${{ protobuf_major_version }}h${{ env.get(PKG_HASH) }}_${{ env.get(PKG_BUILDNUM) }}
       script:
         - if: unix
           then: build_py.sh

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,6 +10,7 @@ context:
   protobuf_version: "5.29.3"
   protobuf_major_version: "5"
   next_protobuf_major_version: "6"
+  build_number: "1"
 
 recipe:
   name: ${{ name }}
@@ -22,7 +23,7 @@ source:
       - win_enable_py_tests.patch
 
 build:
-  number: 1
+  number: ${{ build_number }}
 
 outputs:
   - package:
@@ -86,7 +87,7 @@ outputs:
       name: ${{ python_name }}
     build:
       noarch: python
-      string: protobuf${{ protobuf_major_version }}h${{ hash }}_${{ number }}
+      string: protobuf${{ protobuf_major_version }}h${{ hash }}_${{ build_number }}
       script:
         - if: unix
           then: build_py.sh


### PR DESCRIPTION
On rattler-build, the `PKG_HASH` and `PKG_BUILDNUM` jinja variables are called `hash` and `build_number`.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
