### PR TITLE
[v11] On osx pin clang to 18 for protobuf 5.29.3 compatibility and bump build number to 4

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '19'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '19'
+- '18'
 libabseil:
 - '20250127'
 libprotobuf:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '19'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '19'
+- '18'
 libabseil:
 - '20250127'
 libprotobuf:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,5 @@
+# Workaround for https://github.com/conda-forge/gz-transport-feedstock/pull/68#issuecomment-3112254165
+c_compiler_version:     # [osx]
+  - 18                  # [osx]
+cxx_compiler_version:   # [osx]
+  - 18                  # [osx]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,7 +10,7 @@ context:
   protobuf_version: "5.29.3"
   protobuf_major_version: "5"
   next_protobuf_major_version: "6"
-  build_number: "3"
+  build_number: "4"
 
 recipe:
   name: ${{ name }}


### PR DESCRIPTION
Workaround for https://github.com/conda-forge/gz-transport-feedstock/pull/68#issuecomment-3112254165 .